### PR TITLE
Set S2S_URL environment variable for docker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,8 @@ services:
         - no_proxy
     image: docker.artifactory.reform.hmcts.net/cmc/pdf-service-api
     environment:
+      - S2S_URL
+      # used by java-logging library
       - ROOT_APPENDER
       - JSON_CONSOLE_PRETTY_PRINT
       - ROOT_LOGGING_LEVEL


### PR DESCRIPTION
### JIRA link (if applicable) ###

[Publish Swagger Docs](https://tools.hmcts.net/jira/browse/RPE-148)

### Change description ###

Missing environment variable for api properly start in docker

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
