### PR TITLE
Use empty s2s url by default

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,4 +6,4 @@ management:
     enabled: false
 
 s2s:
-  url: ${S2S_URL}
+  url: ${S2S_URL:}


### PR DESCRIPTION
### Change description ###

As this is not needed by the app yet (only v2 validates tokens)
