### PR TITLE
Enforce UTF-8 encoding

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/pdf/service/endpoint/v2/PDFGenerationEndpointV2.java
+++ b/src/main/java/uk/gov/hmcts/reform/pdf/service/endpoint/v2/PDFGenerationEndpointV2.java
@@ -25,7 +25,7 @@ import uk.gov.hmcts.reform.pdf.service.service.AuthorisationService;
 )
 public class PDFGenerationEndpointV2 {
 
-    public static final String MEDIA_TYPE = "application/vnd.uk.gov.hmcts.pdf-service.v2+json";
+    public static final String MEDIA_TYPE = "application/vnd.uk.gov.hmcts.pdf-service.v2+json;charset=UTF-8";
 
     private static final Logger log = LoggerFactory.getLogger(PDFGenerationEndpointV2.class);
 


### PR DESCRIPTION
### Change description ###

Enforce UTF-8 encoding on the endpoint. Without that, Feign clients used a different encoding which caused JSON deserialisation to fail.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
