### PR TITLE
Change packager name back to cmc

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,7 @@ properties(
 import uk.gov.hmcts.Packager
 import uk.gov.hmcts.Versioner
 
-Packager packager = new Packager(this, 'reform')
+Packager packager = new Packager(this, 'cmc')
 Versioner versioner = new Versioner(this)
 
 def channel = '#platform-engineering'


### PR DESCRIPTION
No need to deal with this on tactical, strategic can be renamed to be whatever we want

