### PR TITLE
Switch to CNP instances of S2S

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -1,3 +1,8 @@
+locals {
+  ase_name = "${data.terraform_remote_state.core_apps_compute.ase_name[0]}"
+  s2s_url = "http://rpe-service-auth-provider-${var.env}.service.${local.ase_name}.internal"
+}
+
 module "pdf-service-api" {
   source = "git@github.com:contino/moj-module-webapp.git?ref=master"
   product = "${var.product}-${var.microservice}"
@@ -7,7 +12,7 @@ module "pdf-service-api" {
   subscription = "${var.subscription}"
 
   app_settings = {
-    S2S_URL = "${var.s2s_url}"
+    S2S_URL = "${local.s2s_url}"
 
     ROOT_APPENDER = "CONSOLE"
     REFORM_TEAM = "${var.product}"

--- a/infrastructure/prod.tfvars
+++ b/infrastructure/prod.tfvars
@@ -1,1 +1,0 @@
-s2s_url = "https://prod-s2s-api.reform.hmcts.net:3511"

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -17,10 +17,6 @@ variable "env" {
   type = "string"
 }
 
-variable "s2s_url" {
-  default = "http://betaDevBccidamS2SLB.reform.hmcts.net"
-}
-
 variable "ilbIp"{}
 
 variable "subscription" {}


### PR DESCRIPTION
### Change description ###

Make PDF service refer to S2S instances from CNP, not from tactical. CNP S2S share microservice keys with tactical.

The next immediate step will be switching all other services on CNP to use CNP S2S.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
