### PR TITLE
Improve healthcheck in Docker by using 'spider' flag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /opt/app
 
 COPY build/install/pdf-service /opt/app/
 
-HEALTHCHECK --interval=10s --timeout=10s --retries=10 CMD http_proxy= wget -q http://localhost:5500/health || exit 1
+HEALTHCHECK --interval=10s --timeout=10s --retries=10 CMD http_proxy="" wget -q --spider http://localhost:5500/health || exit 1
 
 EXPOSE 5500
 


### PR DESCRIPTION
### Change description ###
wget was trying to download 'health' from 'http://localhost:5500/health' and failing, leading to an unhealthy container.
By using the --spider command, we check for a 200 response instead.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
