### PR TITLE
CNP-1155-Java-chart-version - prevent pod from running container process as root

### DIFF
--- a/charts/cmc-pdf-service/requirements.yaml
+++ b/charts/cmc-pdf-service/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
   - name: java
-    version: >=0.0.10
+    version: 0.0.12
     repository: '@hmcts'

--- a/charts/cmc-pdf-service/requirements.yaml
+++ b/charts/cmc-pdf-service/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
   - name: java
-    version: 0.0.12
+    version: ~0.0.12
     repository: '@hmcts'

--- a/charts/cmc-pdf-service/requirements.yaml
+++ b/charts/cmc-pdf-service/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
   - name: java
-    version: 0.0.11
+    version: >=0.0.10
     repository: '@hmcts'


### PR DESCRIPTION
This change will prevent pod from running container processes as root, please refer to the documentation for more details:
https://tools.hmcts.net/confluence/display/CNP/Pod+Security#PodSecurity-SecurityContext

IMPORTANT: Please ensure to update java helm chart version as we might be deleting/deprecating older helm charts from Azure Container Registry which will make the AKS preview deployments fail

**Before creating a pull request make sure that:**

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)

Please remove this line and everything above and fill the following sections:


### JIRA link (if applicable) ###



### Change description ###



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
